### PR TITLE
More additions to the RPC

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -116,7 +116,7 @@
 	<haxelib name="newgrounds"/>
 	<haxelib name="faxe" if='switch'/>
 	<haxelib name="polymod"/>
-	<haxelib name="discord_rpc" unless="web"/>
+	<haxelib name="discord_rpc" if="desktop"/>
 	<!-- <haxelib name="hxcpp-debug-server" if="desktop"/> -->
 
 	<!-- <haxelib name="markdown" /> -->

--- a/source/Discord.hx
+++ b/source/Discord.hx
@@ -57,13 +57,16 @@ class DiscordClient
 		trace("Discord Client initialized");
 	}
 
-	public static function changePresence(details:String, state:Null<String>)
+	public static function changePresence(details:String, state:Null<String>, ?smallImageKey : String, ?startTimestamp: Int, ?endTimestamp: Int)
 	{
 		DiscordRpc.presence({
 			details: details,
 			state: state,
 			largeImageKey: 'icon',
-			largeImageText: "Friday Night Funkin'"
+			largeImageText: "Friday Night Funkin'",
+			smallImageKey : smallImageKey,
+			startTimestamp : startTimestamp,
+            endTimestamp : endTimestamp
 		});
 	}
 }

--- a/source/Discord.hx
+++ b/source/Discord.hx
@@ -57,16 +57,26 @@ class DiscordClient
 		trace("Discord Client initialized");
 	}
 
-	public static function changePresence(details:String, state:Null<String>, ?smallImageKey : String, ?startTimestamp: Int, ?endTimestamp: Int)
+	public static function changePresence(details:String, state:Null<String>, ?smallImageKey : String, ?hasStartTimestamp : Bool, ?endTimestamp: Float)
 	{
+		var startTimestamp:Float = if(hasStartTimestamp) Date.now().getTime() else 0;
+
+		if (endTimestamp > 0)
+		{
+			endTimestamp = startTimestamp + endTimestamp;
+		}
+
 		DiscordRpc.presence({
 			details: details,
 			state: state,
 			largeImageKey: 'icon',
 			largeImageText: "Friday Night Funkin'",
 			smallImageKey : smallImageKey,
-			startTimestamp : startTimestamp,
-            endTimestamp : endTimestamp
+			// Obtained times are in milliseconds so they are divided so Discord can use it
+			startTimestamp : Std.int(startTimestamp / 1000),
+            endTimestamp : Std.int(endTimestamp / 1000)
 		});
+
+		trace('Discord RPC Updated. Argument: $details, $state, $smallImageKey, $hasStartTimestamp, $endTimestamp');
 	}
 }

--- a/source/Discord.hx
+++ b/source/Discord.hx
@@ -77,6 +77,6 @@ class DiscordClient
             endTimestamp : Std.int(endTimestamp / 1000)
 		});
 
-		trace('Discord RPC Updated. Argument: $details, $state, $smallImageKey, $hasStartTimestamp, $endTimestamp');
+		//trace('Discord RPC Updated. Arguments: $details, $state, $smallImageKey, $hasStartTimestamp, $endTimestamp');
 	}
 }

--- a/source/FreeplayState.hx
+++ b/source/FreeplayState.hx
@@ -1,6 +1,6 @@
 package;
 
-#if !html
+#if desktop
 import Discord.DiscordClient;
 #end
 import flash.text.TextField;
@@ -48,9 +48,9 @@ class FreeplayState extends MusicBeatState
 			}
 		 */
 
-		#if !html
+		#if desktop
 		// Updating Discord Rich Presence
-		DiscordClient.changePresence("In the menus.", null);
+		DiscordClient.changePresence("In the Menus", null);
 		#end
 
 		var isDebug:Bool = false;

--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -1,5 +1,8 @@
 package;
 
+#if desktop
+import Discord.DiscordClient;
+#end
 import flixel.FlxG;
 import flixel.FlxObject;
 import flixel.FlxSprite;
@@ -33,6 +36,11 @@ class MainMenuState extends MusicBeatState
 
 	override function create()
 	{
+		#if desktop
+		// Updating Discord Rich Presence
+		DiscordClient.changePresence("In the Menus", null);
+		#end
+
 		transIn = FlxTransitionableState.defaultTransIn;
 		transOut = FlxTransitionableState.defaultTransOut;
 

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -130,6 +130,8 @@ class PlayState extends MusicBeatState
 	var storyDifficultyText:String = "";
 	var iconRPC:String = "";
 	var songLength:Float = 0;
+	var detailsText:String = "";
+	var detailsPausedText:String = "";
 	#end
 
 	override public function create()
@@ -207,16 +209,22 @@ class PlayState extends MusicBeatState
 			case 'mom-car':
 				iconRPC = 'mom';
 		}
-		
-		// Updating Discord Rich Presence.
+
+		// String that contains the mode defined here so it isn't necessary to call changePresence for each mode
 		if (isStoryMode)
 		{
-			DiscordClient.changePresence("Story Mode: Week " + storyWeek, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+			detailsText = "Story Mode: Week " + storyWeek;
 		}
 		else
 		{
-			DiscordClient.changePresence("Freeplay", SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+			detailsText = "Freeplay";
 		}
+
+		// String for when the game is paused
+		detailsPausedText = "Paused - " + detailsText;
+		
+		// Updating Discord Rich Presence.
+		DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
 		#end
 
 		if (SONG.song.toLowerCase() == 'spookeez' || SONG.song.toLowerCase() == 'monster' || SONG.song.toLowerCase() == 'south')
@@ -1018,14 +1026,7 @@ class PlayState extends MusicBeatState
 		songLength = FlxG.sound.music.length;
 
 		// Updating Discord Rich Presence (with Time Left)
-		if (isStoryMode)
-		{
-			DiscordClient.changePresence("Story Mode: Week " + storyWeek, SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength);
-		}
-		else
-		{
-			DiscordClient.changePresence("Freeplay", SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength);
-		}
+		DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength);
 		#end
 	}
 
@@ -1267,6 +1268,17 @@ class PlayState extends MusicBeatState
 			if (!startTimer.finished)
 				startTimer.active = true;
 			paused = false;
+
+			#if !html
+			if (startTimer.finished)
+			{
+				DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength - Conductor.songPosition);
+			}
+			else
+			{
+				DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+			}
+			#end
 		}
 
 		super.closeSubState();
@@ -1334,6 +1346,10 @@ class PlayState extends MusicBeatState
 			}
 			else
 				openSubState(new PauseSubState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
+		
+			#if !html
+			DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+			#end
 		}
 
 		if (FlxG.keys.justPressed.SEVEN)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1586,8 +1586,10 @@ class PlayState extends MusicBeatState
 
 			// FlxG.switchState(new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 			
+			#if desktop
 			// Game Over doesn't get his own variable because it's only used here
 			DiscordClient.changePresence("Game Over - " + detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+			#end
 		}
 
 		if (unspawnNotes[0] != null)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -125,6 +125,13 @@ class PlayState extends MusicBeatState
 
 	var inCutscene:Bool = false;
 
+	#if !html
+	// Discord RPC variables
+	var storyDifficultyText:String = "";
+	var iconRPC:String = "";
+	var songLength:Float = 0;
+	#end
+
 	override public function create()
 	{
 		if (FlxG.sound.music != null)
@@ -178,7 +185,6 @@ class PlayState extends MusicBeatState
 
 		#if !html
 		// Making difficulty text for Discord Rich Presence.
-		var storyDifficultyText = "";
 		switch (storyDifficulty)
 		{
 			case 0:
@@ -188,14 +194,28 @@ class PlayState extends MusicBeatState
 			case 2:
 				storyDifficultyText = "Hard";
 		}
+
+		iconRPC = SONG.player2;
+
+		// To avoid having duplicate images in Discord assets
+		switch (iconRPC)
+		{
+			case 'senpai-angry':
+				iconRPC = 'senpai';
+			case 'monster-christmas':
+				iconRPC = 'monster';
+			case 'mom-car':
+				iconRPC = 'mom';
+		}
+		
 		// Updating Discord Rich Presence.
 		if (isStoryMode)
 		{
-			DiscordClient.changePresence("Story Mode: Week " + storyWeek, SONG.song + " (" + storyDifficultyText + ")");
+			DiscordClient.changePresence("Story Mode: Week " + storyWeek, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
 		}
 		else
 		{
-			DiscordClient.changePresence("Freeplay", SONG.song + " (" + storyDifficultyText + ")");
+			DiscordClient.changePresence("Freeplay", SONG.song + " (" + storyDifficultyText + ")", iconRPC);
 		}
 		#end
 
@@ -992,6 +1012,21 @@ class PlayState extends MusicBeatState
 			FlxG.sound.playMusic(Paths.inst(PlayState.SONG.song), 1, false);
 		FlxG.sound.music.onComplete = endSong;
 		vocals.play();
+
+		#if !html
+		// Song duration in a float, useful for the time left feature
+		songLength = FlxG.sound.music.length;
+
+		// Updating Discord Rich Presence (with Time Left)
+		if (isStoryMode)
+		{
+			DiscordClient.changePresence("Story Mode: Week " + storyWeek, SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength);
+		}
+		else
+		{
+			DiscordClient.changePresence("Freeplay", SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength);
+		}
+		#end
 	}
 
 	var debugNum:Int = 0;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1284,6 +1284,37 @@ class PlayState extends MusicBeatState
 		super.closeSubState();
 	}
 
+	override public function onFocus():Void
+	{
+		#if !html
+		if (health > 0 && !paused)
+		{
+			if (Conductor.songPosition > 0.0)
+			{
+				DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength - Conductor.songPosition);
+			}
+			else
+			{
+				DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+			}
+		}
+		#end
+
+		super.onFocus();
+	}
+	
+	override public function onFocusLost():Void
+	{
+		#if !html
+		if (health > 0 && !paused)
+		{
+			DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
+		}
+		#end
+
+		super.onFocusLost();
+	}
+
 	function resyncVocals():Void
 	{
 		vocals.pause();
@@ -1550,6 +1581,9 @@ class PlayState extends MusicBeatState
 			openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
 			// FlxG.switchState(new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
+			
+			// Game Over doesn't get his own variable because it's only used here
+			DiscordClient.changePresence("Game Over - " + detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
 		}
 
 		if (unspawnNotes[0] != null)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1,6 +1,6 @@
 package;
 
-#if !html
+#if desktop
 import Discord.DiscordClient;
 #end
 import Section.SwagSection;
@@ -125,7 +125,7 @@ class PlayState extends MusicBeatState
 
 	var inCutscene:Bool = false;
 
-	#if !html
+	#if desktop
 	// Discord RPC variables
 	var storyDifficultyText:String = "";
 	var iconRPC:String = "";
@@ -185,7 +185,7 @@ class PlayState extends MusicBeatState
 				dialogue = CoolUtil.coolTextFile(Paths.txt('thorns/thornsDialogue'));
 		}
 
-		#if !html
+		#if desktop
 		// Making difficulty text for Discord Rich Presence.
 		switch (storyDifficulty)
 		{
@@ -1021,7 +1021,7 @@ class PlayState extends MusicBeatState
 		FlxG.sound.music.onComplete = endSong;
 		vocals.play();
 
-		#if !html
+		#if desktop
 		// Song duration in a float, useful for the time left feature
 		songLength = FlxG.sound.music.length;
 
@@ -1269,7 +1269,7 @@ class PlayState extends MusicBeatState
 				startTimer.active = true;
 			paused = false;
 
-			#if !html
+			#if desktop
 			if (startTimer.finished)
 			{
 				DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconRPC, true, songLength - Conductor.songPosition);
@@ -1286,7 +1286,7 @@ class PlayState extends MusicBeatState
 
 	override public function onFocus():Void
 	{
-		#if !html
+		#if desktop
 		if (health > 0 && !paused)
 		{
 			if (Conductor.songPosition > 0.0)
@@ -1305,7 +1305,7 @@ class PlayState extends MusicBeatState
 	
 	override public function onFocusLost():Void
 	{
-		#if !html
+		#if desktop
 		if (health > 0 && !paused)
 		{
 			DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
@@ -1378,7 +1378,7 @@ class PlayState extends MusicBeatState
 			else
 				openSubState(new PauseSubState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 		
-			#if !html
+			#if desktop
 			DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconRPC);
 			#end
 		}
@@ -1386,6 +1386,10 @@ class PlayState extends MusicBeatState
 		if (FlxG.keys.justPressed.SEVEN)
 		{
 			FlxG.switchState(new ChartingState());
+
+			#if desktop
+			DiscordClient.changePresence("Chart Editor", null, null, true);
+			#end
 		}
 
 		// FlxG.watch.addQuick('VOL', vocals.amplitudeLeft);

--- a/source/StoryMenuState.hx
+++ b/source/StoryMenuState.hx
@@ -1,6 +1,6 @@
 package;
 
-#if !html
+#if desktop
 import Discord.DiscordClient;
 #end
 import flixel.FlxG;
@@ -112,9 +112,10 @@ class StoryMenuState extends MusicBeatState
 		add(grpLocks);
 
 		trace("Line 70");
-		#if !html
+		
+		#if desktop
 		// Updating Discord Rich Presence
-		DiscordClient.changePresence("In the menus.", null);
+		DiscordClient.changePresence("In the Menus", null);
 		#end
 
 		for (i in 0...weekData.length)

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -1,6 +1,6 @@
 package;
 
-#if !html5
+#if desktop
 import Discord.DiscordClient;
 import sys.thread.Thread;
 #end
@@ -94,7 +94,7 @@ class TitleState extends MusicBeatState
 		});
 		#end
 
-		#if !html
+		#if desktop
 		DiscordClient.initialize();
 		#end
 	}


### PR DESCRIPTION
First of all, this fixes a little oversight, when exiting a song from the pause menu, the RPC doesn't update and still shows the song.

The RPC now uses the little icon option to show the enemy's icon:
![1](https://user-images.githubusercontent.com/25833407/109404586-54a98700-7946-11eb-8f9a-38237f0b4e98.png)

Also, when the song starts, the RPC now shows how much time is left:
![2](https://user-images.githubusercontent.com/25833407/109404573-32b00480-7946-11eb-812d-208151733e2e.png)

And to prevent the time from going down when the game is paused, pausing the game updates the RPC:
![3](https://user-images.githubusercontent.com/25833407/109404512-95ed6700-7945-11eb-84b3-cfc1086c2b8b.png)
This also is done when alt-tabbing/switching windows.

Again, to prevent the timer showing itself when it shouldn't be, when the Game Over shows up the RPC is updated:
![4](https://user-images.githubusercontent.com/25833407/109404526-c503d880-7945-11eb-8403-27571caa7110.png)

Now the RPC is updated when entering the Debug Mode/Chart Editor:
![5](https://user-images.githubusercontent.com/25833407/109404544-f9779480-7945-11eb-8c4d-ded56717e0e0.png)

These are the assets in Discord side to show the icons:
![chrome_Aero5k3YPJ](https://user-images.githubusercontent.com/25833407/109404716-722b2080-7947-11eb-86ae-10df3a3c0d59.png)

All the "#if !html" was replaced with "#if desktop", first because RPC (in Discord side) is only supported in desktop platforms, and also because a Switch build can be done from the official repository and this probably would conflict with that.

I know this is a fork of the game, but I want to contribute to this feature, so I guess this the way to do it.